### PR TITLE
Add Settings page

### DIFF
--- a/include/class-settings.php
+++ b/include/class-settings.php
@@ -1,0 +1,121 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class KokkieH_Settings {
+    private const SETTINGS_SECTION = 'kokkieh_quote_spa_main';
+    private const PAGE_SLUG        = 'kokkieh_random_quote_spa';
+
+    public function __construct() {
+        // Register Settings
+        add_action( 'admin_init', array( $this, 'kokkieh_quote_spa_register_settings' ) );
+
+        // Add a menu item
+        add_action('admin_menu', array( $this, 'kokkieh_quote_spa_create_menu' ), 100);
+    }
+    
+    // Create Settings menu item
+
+    public function kokkieh_quote_spa_create_menu() {
+        add_options_page(
+            __( 'Random Quote SPA Settings', 'kokkieh-random-quote-spa' ),
+            __( 'Random Quote SPA', 'kokkieh-random-quote-spa' ),
+            'manage_options',
+            self::PAGE_SLUG,
+            array( $this, 'kokkieh_quote_spa_settings_page' ),
+        );
+    }
+
+    // Create Settings page
+
+    public function kokkieh_quote_spa_settings_page() {
+        ?>
+        <div class="wrap">
+            <h2><?php _e( 'Random Quote SPA', 'kokkieh-random-quote-spa' ) ?></h2>
+            <form method="POST" action="options.php">
+            <?php
+                settings_fields( self::PAGE_SLUG );
+                do_settings_sections( self::PAGE_SLUG );
+                submit_button( __( 'Save Changes', 'kokkieh-random-quote-spa' ), 'primary' );
+            ?>
+            </form>
+            <p><?php echo $this->kokkieh_quote_spa_attribution_link() ?></p>
+        </div>
+        <?php
+    }
+
+    // Add settings to page
+
+    public function kokkieh_quote_spa_register_settings() {
+        // Create a section
+        add_settings_section(
+            self::SETTINGS_SECTION,
+            __( 'API Credentials', 'kokkieh-random-quote-spa' ),
+            array( $this, 'kokkieh_quote_spa_section_text'),
+            self::PAGE_SLUG
+        );
+    
+        // Username
+        add_settings_field(
+            'kokkieh_quote_spa_username',
+            __( 'Username', 'kokkieh-random-quote-spa' ),
+            array( $this, 'kokkieh_quote_spa_render_username'),
+            self::PAGE_SLUG,
+            self::SETTINGS_SECTION
+        );
+
+        // API key
+        add_settings_field(
+            'kokkieh_quote_spa_api_key',
+            __( 'API Key', 'kokkieh-random-quote-spa' ),
+            array( $this, 'kokkieh_quote_spa_render_api_key'),
+            self::PAGE_SLUG,
+            self::SETTINGS_SECTION
+        );
+
+        register_setting( self::PAGE_SLUG, 'kokkieh_quote_spa_username' );
+        register_setting( self::PAGE_SLUG, 'kokkieh_quote_spa_api_key' );
+    }
+
+    // Insert section description
+
+    public function kokkieh_quote_spa_section_text() {
+        echo '<p>' . __('Quotes.net API Credentials', 'kokkieh-random-quote-spa' ) . '</p>';
+    }
+
+    // Insert form values
+
+    public function kokkieh_quote_spa_render_username() {
+        $this->kokkieh_quote_spa_render_options( 'kokkieh_quote_spa_username' );
+    }
+
+    public function kokkieh_quote_spa_render_api_key() {
+        $this->kokkieh_quote_spa_render_options( 'kokkieh_quote_spa_api_key' );
+    }
+
+    private function kokkieh_quote_spa_render_options( $option_name ) {
+        $options = get_option( $option_name );
+        $name = $options[ 'name' ];
+        echo "<input id='name' 
+            name='" . esc_attr( $option_name ) . "[name]'
+            type='text' 
+            value='" . esc_attr( $name ) . "'/>";
+    }
+
+    // Function to add API attribution text
+
+    public function kokkieh_quote_spa_attribution_link() {
+        $kokkieh_quote_spa_attr_url = 'http://www.quotes.net/quotes_api.php';
+        return sprintf(
+            esc_html__( 'Powered by the STANDS4 Web Services %s', 'kokkieh-random-quote-spa'),
+            sprintf(
+                '<a href="%s">%s</a>',
+                $kokkieh_quote_spa_attr_url,
+                esc_html__( 'Quotes API', 'kokkieh-random-quote-spa' )
+            )
+        );
+    }
+
+}

--- a/random-quote-spa.php
+++ b/random-quote-spa.php
@@ -12,4 +12,6 @@
  * @package         Random_Quote_Spa
  */
 
-// Your code starts here.
+// Register custom plugin settings
+require_once __DIR__ . '/include/class-settings.php';
+new KokkieH_Settings();


### PR DESCRIPTION
This adds a settings page for the user to input credentials for the quotes API that will be used to generate the quotes.

**To test this pull request**

* Check out this PR and copy the folder into your test site's `/plugins` folder (if you're using Docker and `wp-env`, navigate to the plugin folder in the command line and run `wp-env start`)
* Log into WP-Admin and activate the plugin
* Under Settings should be a new menu item, Random Quote SPA:
<img width="394" alt="Plugins_‹_Random_quote_SPA_—_WordPress" src="https://user-images.githubusercontent.com/11873759/161821933-c27e98ef-77bf-487b-9480-dc0f49b8dffa.png">

* Visit Settings page and ensure it loads:
<img width="590" alt="Random_Quote_SPA_Settings_‹_Random_quote_SPA_—_WordPress" src="https://user-images.githubusercontent.com/11873759/161822099-378b7dd7-ba49-43f0-8a80-0dffa86cc519.png">

* Enter a username and API key and save. Navigate away and return to settings page and ensure entered credentials are still visible
* Change or completely remove credentials and repeat previous step to confirm the changes saved