### PR TITLE
Add/rest api endpoint

### DIFF
--- a/include/cass-rest-api.php
+++ b/include/cass-rest-api.php
@@ -1,9 +1,0 @@
-<?php
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-class KokkieH_quote_spa_REST_API {
-    
-}

--- a/include/cass-rest-api.php
+++ b/include/cass-rest-api.php
@@ -1,0 +1,9 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class KokkieH_quote_spa_REST_API {
+    
+}

--- a/include/class-rest-api.php
+++ b/include/class-rest-api.php
@@ -1,0 +1,50 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class KokkieH_quote_spa_REST_API {
+
+    public function __construct() {
+        add_action( 'rest_api_init', array( $this, 'kokkieh_quote_spa_register_endpoints' ) );
+    }
+
+    // Register new route
+    public function kokkieh_quote_spa_register_endpoints() {
+        register_rest_route(
+            'kokkieh/v1', 
+            '/quote', 
+            array(
+                'methods' => 'GET',
+                'callback' => array( $this, 'kokkieh_quote_spa_get_quote' ),
+            )
+        );
+    }
+
+    // API call to fetch remote data
+    public function kokkieh_quote_spa_get_quote() {
+        $quotes_url = $this->kokkieh_quote_spa_get_url();
+        if ( is_wp_error( $quotes_url ) ) {
+            return false;
+        }
+        $quotes_request = wp_remote_get( $quotes_url );
+        if ( is_wp_error( $quotes_request ) ) {
+            return false;
+        }
+        $quotes_content = wp_remote_retrieve_body( $quotes_request );
+        return json_decode( $quotes_content, true );
+    }
+
+    // Construct URL for fetching remote data
+    private function kokkieh_quote_spa_get_url() {
+        $user_id  = get_option( 'kokkieh_quote_spa_user_id' );
+        $api_key = get_option( 'kokkieh_quote_spa_api_key' );
+
+        if ( empty( $user_id ) || empty( $api_key ) ) {
+            return new WP_Error( 'Cannot retrieve user ID or API key. Please visit the plugin\'s settings page.' );
+        }
+
+        return "https://www.stands4.com/services/v2/quotes.php?uid={$user_id}&tokenid={$api_key}&searchtype=AUTHOR&query=William+Shakespeare&format=json";
+    }
+}

--- a/include/class-settings.php
+++ b/include/class-settings.php
@@ -57,11 +57,11 @@ class KokkieH_Settings {
             self::PAGE_SLUG
         );
     
-        // Username
+        // User ID
         add_settings_field(
-            'kokkieh_quote_spa_username',
-            __( 'Username', 'kokkieh-random-quote-spa' ),
-            array( $this, 'kokkieh_quote_spa_render_username'),
+            'kokkieh_quote_spa_user_id',
+            __( 'User ID', 'kokkieh-random-quote-spa' ),
+            array( $this, 'kokkieh_quote_spa_render_user_id'),
             self::PAGE_SLUG,
             self::SETTINGS_SECTION
         );
@@ -75,7 +75,7 @@ class KokkieH_Settings {
             self::SETTINGS_SECTION
         );
 
-        register_setting( self::PAGE_SLUG, 'kokkieh_quote_spa_username' );
+        register_setting( self::PAGE_SLUG, 'kokkieh_quote_spa_user_id' );
         register_setting( self::PAGE_SLUG, 'kokkieh_quote_spa_api_key' );
     }
 
@@ -87,8 +87,8 @@ class KokkieH_Settings {
 
     // Insert form values
 
-    public function kokkieh_quote_spa_render_username() {
-        $this->kokkieh_quote_spa_render_options( 'kokkieh_quote_spa_username' );
+    public function kokkieh_quote_spa_render_user_id() {
+        $this->kokkieh_quote_spa_render_options( 'kokkieh_quote_spa_user_id' );
     }
 
     public function kokkieh_quote_spa_render_api_key() {

--- a/include/class-settings.php
+++ b/include/class-settings.php
@@ -96,12 +96,10 @@ class KokkieH_Settings {
     }
 
     private function kokkieh_quote_spa_render_options( $option_name ) {
-        $options = get_option( $option_name );
-        $name = $options[ 'name' ];
-        echo "<input id='name' 
-            name='" . esc_attr( $option_name ) . "[name]'
-            type='text' 
-            value='" . esc_attr( $name ) . "'/>";
+        echo "<input type='text' 
+            id='" . esc_attr( $option_name ) . "' 
+            name='" . esc_attr( $option_name ) . "'
+            value='" . get_option( $option_name ) . "'/>";
     }
 
     // Function to add API attribution text

--- a/random-quote-spa.php
+++ b/random-quote-spa.php
@@ -15,3 +15,7 @@
 // Register custom plugin settings
 require_once __DIR__ . '/include/class-settings.php';
 new KokkieH_Settings();
+
+// Register custom API endpoint
+require_once __DIR__ . '/include/class-rest-api.php';
+new KokkieH_quote_spa_REST_API();


### PR DESCRIPTION
This PR extends the WordPress REST API to fetch quotes from the stands4.com web API, as per #1 

**Testing instructions**

* Visit plugin settings page and enter valid API credentials for the stands4.com Quotes API
* In your browser, view `{site_URL}/wp-json/kokkieh/v1/quote` - it should display a JSON object containing quotes from William Shakespeare
